### PR TITLE
change time interval to 5 second and add log4net-loggly.nuspec file

### DIFF
--- a/source/log4net-loggly/LogglyAppender.cs
+++ b/source/log4net-loggly/LogglyAppender.cs
@@ -31,7 +31,7 @@ namespace log4net.loggly
 		{
 			LogglyAsync = new LogglyAsyncHandler();
 			Timer.Timer t = new Timer.Timer();
-			t.Interval = 20000;
+			t.Interval = 5000;
 			t.Enabled = true;
 			t.Elapsed += t_Elapsed;
 		}

--- a/source/log4net-loggly/log4net-loggly.nuspec
+++ b/source/log4net-loggly/log4net-loggly.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>log4net-loggly</id>
+    <version>7.2.3</version>
+    <authors>Loggly</authors>
+    <owners>Loggly</owners>
+    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+    <projectUrl>http://github.com/loggly/log4net-loggly</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Custom log4Net Appender to send logs to Loggly</description>
+    <releaseNotes>Decrease wait time interval for bulk mode.</releaseNotes>
+    <copyright>Copyright 2016</copyright>
+    <tags>Loggly-log4net log4net appender logs</tags>
+    <dependencies>
+      <dependency id="log4net" version="2.0.3" />
+      <dependency id="Newtonsoft.Json" version="8.0.1" />
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
@mostlyjason: In bulk mode, Logs wait for 20000 milliseconds (20 seconds) to send logs to the loggly.
When application exit within 20 second after sending the log, it doesn't reach to the loggly.
We should decrease wait time interval to overcome the above issue.

Also, I have added the log4net-loggly.nuspec file that will be helpful to publish new NuGet package in future.

Kindly Review!

cc: @mchaudhary 

