### PR TITLE
Buffer support in log4net-loggly library during network outage

### DIFF
--- a/source/log4net-loggly/ILogglyAppenderConfig.cs
+++ b/source/log4net-loggly/ILogglyAppenderConfig.cs
@@ -10,5 +10,6 @@ namespace log4net.loggly
 		string Tag { get; set; }
 		string LogicalThreadContextKeys { get; set; }
 		string GlobalContextKeys { get; set; }
+        int BufferSize { get; set; }
 	}
 }

--- a/source/log4net-loggly/ILogglyAppenderConfig.cs
+++ b/source/log4net-loggly/ILogglyAppenderConfig.cs
@@ -10,6 +10,6 @@ namespace log4net.loggly
 		string Tag { get; set; }
 		string LogicalThreadContextKeys { get; set; }
 		string GlobalContextKeys { get; set; }
-        int BufferSize { get; set; }
+		int BufferSize { get; set; }
 	}
 }

--- a/source/log4net-loggly/ILogglyClient.cs
+++ b/source/log4net-loggly/ILogglyClient.cs
@@ -2,6 +2,7 @@ namespace log4net.loggly
 {
 	public interface ILogglyClient
 	{
-		void Send(ILogglyAppenderConfig config, string message);
+        void Send(ILogglyAppenderConfig config, string message);
+        void Send(ILogglyAppenderConfig config, string message, bool isBulk);
 	}
 }

--- a/source/log4net-loggly/ILogglyClient.cs
+++ b/source/log4net-loggly/ILogglyClient.cs
@@ -2,7 +2,7 @@ namespace log4net.loggly
 {
 	public interface ILogglyClient
 	{
-        void Send(ILogglyAppenderConfig config, string message);
-        void Send(ILogglyAppenderConfig config, string message, bool isBulk);
+	void Send(ILogglyAppenderConfig config, string message);
+	void Send(ILogglyAppenderConfig config, string message, bool isBulk);
 	}
 }

--- a/source/log4net-loggly/ILogglyFormatter.cs
+++ b/source/log4net-loggly/ILogglyFormatter.cs
@@ -10,13 +10,13 @@ namespace log4net.loggly
 		string ToJson(LoggingEvent loggingEvent);
 		string ToJson(IEnumerable<LoggingEvent> loggingEvents);
 
-        /// <summary>
-        /// Merged Layout formatted log with the formatted timestamp
-        /// </summary>
-        /// <param name="renderedLog"></param>
-        /// <param name="timeStamp"></param>
-        /// <returns></returns>
-        string ToJson(string renderedLog, DateTime timeStamp);
-        
+		/// <summary>
+		/// Merged Layout formatted log with the formatted timestamp
+		/// </summary>
+		/// <param name="renderedLog"></param>
+		/// <param name="timeStamp"></param>
+		/// <returns></returns>
+		string ToJson(string renderedLog, DateTime timeStamp);
+		
 	}
 }

--- a/source/log4net-loggly/LogglyAppender.cs
+++ b/source/log4net-loggly/LogglyAppender.cs
@@ -8,95 +8,96 @@ using Timer = System.Timers;
 
 namespace log4net.loggly
 {
-	public class LogglyAppender : AppenderSkeleton
-	{
-		List<string> lstLogs = new List<string>();
-		string[] arr = new string[100];
-		public static readonly string InputKeyProperty = "LogglyInputKey";
-		public static ILogglyFormatter Formatter = new LogglyFormatter();
-		public static ILogglyClient Client = new LogglyClient();
-		private ILogglyAppenderConfig Config = new LogglyAppenderConfig();
-		public string RootUrl { set { Config.RootUrl = value; } }
-		public string InputKey { set { Config.InputKey = value; } }
-		public string UserAgent { set { Config.UserAgent = value; } }
-		public string LogMode { set { Config.LogMode = value; } }
-		public int TimeoutInSeconds { set { Config.TimeoutInSeconds = value; } }
-		public string Tag { set { Config.Tag = value; } }
-		public string LogicalThreadContextKeys { set { Config.LogicalThreadContextKeys = value; } }
-		public string GlobalContextKeys { set { Config.GlobalContextKeys = value; } }
+    public class LogglyAppender : AppenderSkeleton
+    {
+        List<string> lstLogs = new List<string>();
+        string[] arr = new string[100];
+        public static readonly string InputKeyProperty = "LogglyInputKey";
+        public static ILogglyFormatter Formatter = new LogglyFormatter();
+        public static ILogglyClient Client = new LogglyClient();
+        private ILogglyAppenderConfig Config = new LogglyAppenderConfig();
+        public string RootUrl { set { Config.RootUrl = value; } }
+        public string InputKey { set { Config.InputKey = value; } }
+        public string UserAgent { set { Config.UserAgent = value; } }
+        public string LogMode { set { Config.LogMode = value; } }
+        public int TimeoutInSeconds { set { Config.TimeoutInSeconds = value; } }
+        public string Tag { set { Config.Tag = value; } }
+        public string LogicalThreadContextKeys { set { Config.LogicalThreadContextKeys = value; } }
+        public string GlobalContextKeys { set { Config.GlobalContextKeys = value; } }
 
-		private LogglyAsyncHandler LogglyAsync;
+        private LogglyAsyncHandler LogglyAsync;
 
-		public LogglyAppender()
-		{
-			LogglyAsync = new LogglyAsyncHandler();
-			Timer.Timer t = new Timer.Timer();
-			t.Interval = 5000;
-			t.Enabled = true;
-			t.Elapsed += t_Elapsed;
-		}
+        public LogglyAppender()
+        {
+            LogglyAsync = new LogglyAsyncHandler();
+            Timer.Timer t = new Timer.Timer();
+            t.Interval = 5000;
+            t.Enabled = true;
+            t.Elapsed += t_Elapsed;
+        }
 
-		void t_Elapsed(object sender, Timer.ElapsedEventArgs e)
-		{
-			if (lstLogs.Count != 0)
-			{
-				SendAllEvents(lstLogs.ToArray());
-			}
-		}
+        void t_Elapsed(object sender, Timer.ElapsedEventArgs e)
+        {
+            if (lstLogs.Count != 0)
+            {
+                SendAllEvents(lstLogs.ToArray());
+            }           
+           LogglySendBufferedLogs.sendBufferedLogsToLoggly(Config, Config.LogMode == "bulk/");
+        }
 
-		protected override void Append(LoggingEvent loggingEvent)
-		{
-			SendLogAction(loggingEvent);
-		}
+        protected override void Append(LoggingEvent loggingEvent)
+        {
+            SendLogAction(loggingEvent);
+        }
 
-		private void SendLogAction(LoggingEvent loggingEvent)
-		{
-			//we should always format event in the same thread as 
-			//many properties used in the event are associated with the current thread
-			//like threadname, ndc stacks, threadcontent properties etc.
+        private void SendLogAction(LoggingEvent loggingEvent)
+        {
+            //we should always format event in the same thread as 
+            //many properties used in the event are associated with the current thread
+            //like threadname, ndc stacks, threadcontent properties etc.
 
-			//initializing a string for the formatted log
-			string _formattedLog = string.Empty;
+            //initializing a string for the formatted log
+            string _formattedLog = string.Empty;
 
-			//if Layout is null then format the log from the Loggly Client
-			if (this.Layout == null)
-			{
-				Formatter.AppendAdditionalLoggingInformation(Config, loggingEvent);
-				_formattedLog = Formatter.ToJson(loggingEvent);
-			}
-			else
-			{
-				_formattedLog = Formatter.ToJson(RenderLoggingEvent(loggingEvent), loggingEvent.TimeStamp);
-			}
+            //if Layout is null then format the log from the Loggly Client
+            if (this.Layout == null)
+            {
+                Formatter.AppendAdditionalLoggingInformation(Config, loggingEvent);
+                _formattedLog = Formatter.ToJson(loggingEvent);
+            }
+            else
+            {
+                _formattedLog = Formatter.ToJson(RenderLoggingEvent(loggingEvent), loggingEvent.TimeStamp);
+            }
 
-			//check if logMode is bulk or inputs
-			if (Config.LogMode == "bulk/")
-			{
-				addToBulk(_formattedLog);
-			}
-			else if (Config.LogMode == "inputs/")
-			{
-				//sending _formattedLog to the async queue
-				LogglyAsync.PostMessage(_formattedLog, Config);
-			}
-		}
+            //check if logMode is bulk or inputs
+            if (Config.LogMode == "bulk/")
+            {
+                addToBulk(_formattedLog);
+            }
+            else if (Config.LogMode == "inputs/")
+            {
+                //sending _formattedLog to the async queue
+                LogglyAsync.PostMessage(_formattedLog, Config);
+            }
+        }
 
-		public void addToBulk(string log)
-		{
-			// store all events into a array max lenght is 100
-			lstLogs.Add(log.Replace("\n", ""));
-			if (lstLogs.Count == 100)
-			{
-				SendAllEvents(lstLogs.ToArray());
-			}
-		}
+        public void addToBulk(string log)
+        {
+            // store all events into a array max lenght is 100
+            lstLogs.Add(log.Replace("\n", ""));
+            if (lstLogs.Count == 100)
+            {
+                SendAllEvents(lstLogs.ToArray());
+            }
+        }
 
-		private void SendAllEvents(string[] events)
-		{
-			lstLogs.Clear();
-			String bulkLog = String.Join(System.Environment.NewLine, events);
-			LogglyAsync.PostMessage(bulkLog, Config);
-		}
+        private void SendAllEvents(string[] events)
+        {
+            lstLogs.Clear();
+            String bulkLog = String.Join(System.Environment.NewLine, events);
+            LogglyAsync.PostMessage(bulkLog, Config);
+        }
 
-	}
-}
+        }
+    }

--- a/source/log4net-loggly/LogglyAppender.cs
+++ b/source/log4net-loggly/LogglyAppender.cs
@@ -8,97 +8,97 @@ using Timer = System.Timers;
 
 namespace log4net.loggly
 {
-    public class LogglyAppender : AppenderSkeleton
-    {
-        List<string> lstLogs = new List<string>();
-        string[] arr = new string[100];
-        public static readonly string InputKeyProperty = "LogglyInputKey";
-        public static ILogglyFormatter Formatter = new LogglyFormatter();
-        public static ILogglyClient Client = new LogglyClient();
-        private ILogglyAppenderConfig Config = new LogglyAppenderConfig();
-        public string RootUrl { set { Config.RootUrl = value; } }
-        public string InputKey { set { Config.InputKey = value; } }
-        public string UserAgent { set { Config.UserAgent = value; } }
-        public string LogMode { set { Config.LogMode = value; } }
-        public int TimeoutInSeconds { set { Config.TimeoutInSeconds = value; } }
-        public string Tag { set { Config.Tag = value; } }
-        public string LogicalThreadContextKeys { set { Config.LogicalThreadContextKeys = value; } }
-        public string GlobalContextKeys { set { Config.GlobalContextKeys = value; } }
-        public int BufferSize { set { Config.BufferSize = value; } }
+	public class LogglyAppender : AppenderSkeleton
+	{
+		List<string> lstLogs = new List<string>();
+		string[] arr = new string[100];
+		public static readonly string InputKeyProperty = "LogglyInputKey";
+		public static ILogglyFormatter Formatter = new LogglyFormatter();
+		public static ILogglyClient Client = new LogglyClient();
+		private ILogglyAppenderConfig Config = new LogglyAppenderConfig();
+		public string RootUrl { set { Config.RootUrl = value; } }
+		public string InputKey { set { Config.InputKey = value; } }
+		public string UserAgent { set { Config.UserAgent = value; } }
+		public string LogMode { set { Config.LogMode = value; } }
+		public int TimeoutInSeconds { set { Config.TimeoutInSeconds = value; } }
+		public string Tag { set { Config.Tag = value; } }
+		public string LogicalThreadContextKeys { set { Config.LogicalThreadContextKeys = value; } }
+		public string GlobalContextKeys { set { Config.GlobalContextKeys = value; } }
+		public int BufferSize { set { Config.BufferSize = value; } }
 
-        private LogglyAsyncHandler LogglyAsync;
+		private LogglyAsyncHandler LogglyAsync;
 
-        public LogglyAppender()
-        {
-            LogglyAsync = new LogglyAsyncHandler();
-            Timer.Timer t = new Timer.Timer();
-            t.Interval = 5000;
-            t.Enabled = true;
-            t.Elapsed += t_Elapsed;
-        }
+		public LogglyAppender()
+		{
+			LogglyAsync = new LogglyAsyncHandler();
+			Timer.Timer t = new Timer.Timer();
+			t.Interval = 5000;
+			t.Enabled = true;
+			t.Elapsed += t_Elapsed;
+		}
 
-        void t_Elapsed(object sender, Timer.ElapsedEventArgs e)
-        {
-            if (lstLogs.Count != 0)
-            {
-                SendAllEvents(lstLogs.ToArray());
-            }           
-           LogglySendBufferedLogs.sendBufferedLogsToLoggly(Config, Config.LogMode == "bulk/");
-        }
+		void t_Elapsed(object sender, Timer.ElapsedEventArgs e)
+		{
+			if (lstLogs.Count != 0)
+			{
+				SendAllEvents(lstLogs.ToArray());
+			}           
+		   LogglySendBufferedLogs.sendBufferedLogsToLoggly(Config, Config.LogMode == "bulk/");
+		}
 
-        protected override void Append(LoggingEvent loggingEvent)
-        {
-            SendLogAction(loggingEvent);
-        }
+		protected override void Append(LoggingEvent loggingEvent)
+		{
+			SendLogAction(loggingEvent);
+		}
 
-        private void SendLogAction(LoggingEvent loggingEvent)
-        {
-            //we should always format event in the same thread as 
-            //many properties used in the event are associated with the current thread
-            //like threadname, ndc stacks, threadcontent properties etc.
+		private void SendLogAction(LoggingEvent loggingEvent)
+		{
+			//we should always format event in the same thread as 
+			//many properties used in the event are associated with the current thread
+			//like threadname, ndc stacks, threadcontent properties etc.
 
-            //initializing a string for the formatted log
-            string _formattedLog = string.Empty;
+			//initializing a string for the formatted log
+			string _formattedLog = string.Empty;
 
-            //if Layout is null then format the log from the Loggly Client
-            if (this.Layout == null)
-            {
-                Formatter.AppendAdditionalLoggingInformation(Config, loggingEvent);
-                _formattedLog = Formatter.ToJson(loggingEvent);
-            }
-            else
-            {
-                _formattedLog = Formatter.ToJson(RenderLoggingEvent(loggingEvent), loggingEvent.TimeStamp);
-            }
+			//if Layout is null then format the log from the Loggly Client
+			if (this.Layout == null)
+			{
+				Formatter.AppendAdditionalLoggingInformation(Config, loggingEvent);
+				_formattedLog = Formatter.ToJson(loggingEvent);
+			}
+			else
+			{
+				_formattedLog = Formatter.ToJson(RenderLoggingEvent(loggingEvent), loggingEvent.TimeStamp);
+			}
 
-            //check if logMode is bulk or inputs
-            if (Config.LogMode == "bulk/")
-            {
-                addToBulk(_formattedLog);
-            }
-            else if (Config.LogMode == "inputs/")
-            {
-                //sending _formattedLog to the async queue
-                LogglyAsync.PostMessage(_formattedLog, Config);
-            }
-        }
+			//check if logMode is bulk or inputs
+			if (Config.LogMode == "bulk/")
+			{
+				addToBulk(_formattedLog);
+			}
+			else if (Config.LogMode == "inputs/")
+			{
+				//sending _formattedLog to the async queue
+				LogglyAsync.PostMessage(_formattedLog, Config);
+			}
+		}
 
-        public void addToBulk(string log)
-        {
-            // store all events into a array max lenght is 100
-            lstLogs.Add(log.Replace("\n", ""));
-            if (lstLogs.Count == 100)
-            {
-                SendAllEvents(lstLogs.ToArray());
-            }
-        }
+		public void addToBulk(string log)
+		{
+			// store all events into a array max lenght is 100
+			lstLogs.Add(log.Replace("\n", ""));
+			if (lstLogs.Count == 100)
+			{
+				SendAllEvents(lstLogs.ToArray());
+			}
+		}
 
-        private void SendAllEvents(string[] events)
-        {
-            lstLogs.Clear();
-            String bulkLog = String.Join(System.Environment.NewLine, events);
-            LogglyAsync.PostMessage(bulkLog, Config);
-        }
+		private void SendAllEvents(string[] events)
+		{
+			lstLogs.Clear();
+			String bulkLog = String.Join(System.Environment.NewLine, events);
+			LogglyAsync.PostMessage(bulkLog, Config);
+		}
 
-        }
-    }
+		}
+	}

--- a/source/log4net-loggly/LogglyAppender.cs
+++ b/source/log4net-loggly/LogglyAppender.cs
@@ -24,6 +24,7 @@ namespace log4net.loggly
         public string Tag { set { Config.Tag = value; } }
         public string LogicalThreadContextKeys { set { Config.LogicalThreadContextKeys = value; } }
         public string GlobalContextKeys { set { Config.GlobalContextKeys = value; } }
+        public int BufferSize { set { Config.BufferSize = value; } }
 
         private LogglyAsyncHandler LogglyAsync;
 

--- a/source/log4net-loggly/LogglyAppenderConfig.cs
+++ b/source/log4net-loggly/LogglyAppenderConfig.cs
@@ -43,6 +43,7 @@ namespace log4net.loggly
 
 		public string GlobalContextKeys { get; set; }
 
+        public int BufferSize { get; set; }
 		public LogglyAppenderConfig()
 		{
 			UserAgent = "loggly-log4net-appender";
@@ -51,6 +52,7 @@ namespace log4net.loggly
 			LogMode = "bulk";
 			LogicalThreadContextKeys = null;
 			GlobalContextKeys = null;
+            BufferSize = 500;
 		}
 	}
 }

--- a/source/log4net-loggly/LogglyAppenderConfig.cs
+++ b/source/log4net-loggly/LogglyAppenderConfig.cs
@@ -43,7 +43,7 @@ namespace log4net.loggly
 
 		public string GlobalContextKeys { get; set; }
 
-        public int BufferSize { get; set; }
+		public int BufferSize { get; set; }
 		public LogglyAppenderConfig()
 		{
 			UserAgent = "loggly-log4net-appender";
@@ -52,7 +52,7 @@ namespace log4net.loggly
 			LogMode = "bulk";
 			LogicalThreadContextKeys = null;
 			GlobalContextKeys = null;
-            BufferSize = 500;
+			BufferSize = 500;
 		}
 	}
 }

--- a/source/log4net-loggly/LogglyBufferringAppender.cs
+++ b/source/log4net-loggly/LogglyBufferringAppender.cs
@@ -18,7 +18,7 @@ namespace log4net.loggly
 		public string LogMode { set { Config.LogMode = value; } }
 		public int TimeoutInSeconds { set { Config.TimeoutInSeconds = value; } }
 		public string Tag { set { Config.Tag = value; } }
-        public int BufferSize { set { Config.BufferSize = value; } }
+		public int BufferSize { set { Config.BufferSize = value; } }
 
 		protected override void Append(LoggingEvent loggingEvent)
 		{

--- a/source/log4net-loggly/LogglyBufferringAppender.cs
+++ b/source/log4net-loggly/LogglyBufferringAppender.cs
@@ -18,6 +18,7 @@ namespace log4net.loggly
 		public string LogMode { set { Config.LogMode = value; } }
 		public int TimeoutInSeconds { set { Config.TimeoutInSeconds = value; } }
 		public string Tag { set { Config.Tag = value; } }
+        public int BufferSize { set { Config.BufferSize = value; } }
 
 		protected override void Append(LoggingEvent loggingEvent)
 		{

--- a/source/log4net-loggly/LogglyClient.cs
+++ b/source/log4net-loggly/LogglyClient.cs
@@ -1,46 +1,105 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Text;
+using System.Linq;
 
 namespace log4net.loggly
 {
 	public class LogglyClient : ILogglyClient
 	{
-		public virtual void Send(ILogglyAppenderConfig config, string message)
-		{
+        static bool isValidToken = true;
+        public static void setValidInvalidFlag(bool flag)
+        {
+           isValidToken = flag;
+        }
+
+        public virtual void Send(ILogglyAppenderConfig config, string message)
+        {
             int maxRetryAllowed = 5;
             int totalRetries = 0;
 
             string _tag = config.Tag;
-            
+            bool isBulk = config.LogMode.Contains("bulk");
+
+            List<string> messageBulk = new List<string>();
             //keeping userAgent backward compatible
             if (!string.IsNullOrWhiteSpace(config.UserAgent))
             {
                 _tag = _tag + "," + config.UserAgent;
             }
 
-            while (totalRetries < maxRetryAllowed)
+            while (isValidToken && totalRetries < maxRetryAllowed)
             {
                 totalRetries++;
                 try
                 {
-			        var bytes = Encoding.UTF8.GetBytes(message);
-                    var webRequest = CreateWebRequest(config, _tag);
+                    var bytes = Encoding.UTF8.GetBytes(message);
+                    var webRequest = CreateWebRequest(config, _tag);  
+                    
+                        using (var dataStream = webRequest.GetRequestStream())
+                        {
+                            dataStream.Write(bytes, 0, bytes.Length);
+                            dataStream.Flush();
+                            dataStream.Close();
+                        }
 
-                    using (var dataStream = webRequest.GetRequestStream())
-			        {
-				        dataStream.Write(bytes, 0, bytes.Length);
-				        dataStream.Flush();
-				        dataStream.Close();
-			        }
-            
-                    var webResponse = webRequest.GetResponse();
-                    webResponse.Close();
-                    break;
+                        var webResponse = webRequest.GetResponse();
+                        webResponse.Close();
+                        break;                    
                 }
-                catch { }
+
+                catch (WebException e) {
+                    var response = (HttpWebResponse)e.Response;
+                    if (response != null) 
+                    {
+                        if (response.StatusCode == HttpStatusCode.Forbidden)  //Check for bad token
+                        {
+                            setValidInvalidFlag(false);
+                        }
+                        if (totalRetries == 1) Console.WriteLine("Loggly error: {0}", e.Message);
+                    }
+
+                    else if (totalRetries == 1)
+                    {
+                        if (isBulk)
+                        {
+                            messageBulk = message.Split('\n').ToList();
+                            LogglyStoreLogsInBuffer.storeBulkLogs(config, messageBulk, isBulk);
+                        }
+                        else
+                        {
+                            LogglyStoreLogsInBuffer.storeInputLogs(config, message, isBulk);
+                        }
+                    }
+                }
+             }
+         }
+
+        public void Send(ILogglyAppenderConfig config, string message, bool isbulk)
+        {
+            if (isValidToken)
+            {
+                string _tag = config.Tag;
+
+                //keeping userAgent backward compatible
+                if (!string.IsNullOrWhiteSpace(config.UserAgent))
+                {
+                    _tag = _tag + "," + config.UserAgent;
+                }
+                var bytes = Encoding.UTF8.GetBytes(message);
+                var webRequest = CreateWebRequest(config, _tag);
+
+                using (var dataStream = webRequest.GetRequestStream())
+                {
+                    dataStream.Write(bytes, 0, bytes.Length);
+                    dataStream.Flush();
+                    dataStream.Close();
+                }
+                var webResponse = (HttpWebResponse)webRequest.GetResponse();
+                webResponse.Close();
             }
-		}
+        }
 
 		protected virtual HttpWebRequest CreateWebRequest(ILogglyAppenderConfig config, string tag)
 		{
@@ -55,5 +114,5 @@ namespace log4net.loggly
 			request.ContentType = "application/json";
 			return request;
 		}
-	}
+    }  
 }

--- a/source/log4net-loggly/LogglyClient.cs
+++ b/source/log4net-loggly/LogglyClient.cs
@@ -8,104 +8,104 @@ namespace log4net.loggly
 {
 	public class LogglyClient : ILogglyClient
 	{
-        static bool isValidToken = true;
-        public static void setValidInvalidFlag(bool flag)
-        {
-           isValidToken = flag;
-        }
+		static bool isValidToken = true;
+		public static void setValidInvalidFlag(bool flag)
+		{
+		   isValidToken = flag;
+		}
 
-        public virtual void Send(ILogglyAppenderConfig config, string message)
-        {
-            int maxRetryAllowed = 5;
-            int totalRetries = 0;
+		public virtual void Send(ILogglyAppenderConfig config, string message)
+		{
+			int maxRetryAllowed = 5;
+			int totalRetries = 0;
 
-            string _tag = config.Tag;
-            bool isBulk = config.LogMode.Contains("bulk");
+			string _tag = config.Tag;
+			bool isBulk = config.LogMode.Contains("bulk");
 
-            List<string> messageBulk = new List<string>();
-            //keeping userAgent backward compatible
-            if (!string.IsNullOrWhiteSpace(config.UserAgent))
-            {
-                _tag = _tag + "," + config.UserAgent;
-            }
+			List<string> messageBulk = new List<string>();
+			//keeping userAgent backward compatible
+			if (!string.IsNullOrWhiteSpace(config.UserAgent))
+			{
+				_tag = _tag + "," + config.UserAgent;
+			}
 
-            while (isValidToken && totalRetries < maxRetryAllowed)
-            {
-                totalRetries++;
-                try
-                {
-                    var bytes = Encoding.UTF8.GetBytes(message);
-                    var webRequest = CreateWebRequest(config, _tag);  
-                    
-                        using (var dataStream = webRequest.GetRequestStream())
-                        {
-                            dataStream.Write(bytes, 0, bytes.Length);
-                            dataStream.Flush();
-                            dataStream.Close();
-                        }
+			while (isValidToken && totalRetries < maxRetryAllowed)
+			{
+				totalRetries++;
+				try
+				{
+					var bytes = Encoding.UTF8.GetBytes(message);
+					var webRequest = CreateWebRequest(config, _tag);  
+					
+						using (var dataStream = webRequest.GetRequestStream())
+						{
+							dataStream.Write(bytes, 0, bytes.Length);
+							dataStream.Flush();
+							dataStream.Close();
+						}
 
-                        var webResponse = webRequest.GetResponse();
-                        webResponse.Close();
-                        break;                    
-                }
+						var webResponse = webRequest.GetResponse();
+						webResponse.Close();
+						break;                    
+				}
 
-                catch (WebException e) {
-                    var response = (HttpWebResponse)e.Response;
-                    if (response != null) 
-                    {
-                        if (response.StatusCode == HttpStatusCode.Forbidden)  //Check for bad token
-                        {
-                            setValidInvalidFlag(false);
-                        }
-                        if (totalRetries == 1) Console.WriteLine("Loggly error: {0}", e.Message);
-                    }
+				catch (WebException e) {
+					var response = (HttpWebResponse)e.Response;
+					if (response != null) 
+					{
+						if (response.StatusCode == HttpStatusCode.Forbidden)  //Check for bad token
+						{
+							setValidInvalidFlag(false);
+						}
+						if (totalRetries == 1) Console.WriteLine("Loggly error: {0}", e.Message);
+					}
 
-                    else if (totalRetries == 1)
-                    {
-                        if (isBulk)
-                        {
-                            messageBulk = message.Split('\n').ToList();
-                            LogglyStoreLogsInBuffer.storeBulkLogs(config, messageBulk, isBulk);
-                        }
-                        else
-                        {
-                            LogglyStoreLogsInBuffer.storeInputLogs(config, message, isBulk);
-                        }
-                    }
-                }
-             }
-         }
+					else if (totalRetries == 1)
+					{
+						if (isBulk)
+						{
+							messageBulk = message.Split('\n').ToList();
+							LogglyStoreLogsInBuffer.storeBulkLogs(config, messageBulk, isBulk);
+						}
+						else
+						{
+							LogglyStoreLogsInBuffer.storeInputLogs(config, message, isBulk);
+						}
+					}
+				}
+			 }
+		 }
 
-        public void Send(ILogglyAppenderConfig config, string message, bool isbulk)
-        {
-            if (isValidToken)
-            {
-                string _tag = config.Tag;
+		public void Send(ILogglyAppenderConfig config, string message, bool isbulk)
+		{
+			if (isValidToken)
+			{
+				string _tag = config.Tag;
 
-                //keeping userAgent backward compatible
-                if (!string.IsNullOrWhiteSpace(config.UserAgent))
-                {
-                    _tag = _tag + "," + config.UserAgent;
-                }
-                var bytes = Encoding.UTF8.GetBytes(message);
-                var webRequest = CreateWebRequest(config, _tag);
+				//keeping userAgent backward compatible
+				if (!string.IsNullOrWhiteSpace(config.UserAgent))
+				{
+					_tag = _tag + "," + config.UserAgent;
+				}
+				var bytes = Encoding.UTF8.GetBytes(message);
+				var webRequest = CreateWebRequest(config, _tag);
 
-                using (var dataStream = webRequest.GetRequestStream())
-                {
-                    dataStream.Write(bytes, 0, bytes.Length);
-                    dataStream.Flush();
-                    dataStream.Close();
-                }
-                var webResponse = (HttpWebResponse)webRequest.GetResponse();
-                webResponse.Close();
-            }
-        }
+				using (var dataStream = webRequest.GetRequestStream())
+				{
+					dataStream.Write(bytes, 0, bytes.Length);
+					dataStream.Flush();
+					dataStream.Close();
+				}
+				var webResponse = (HttpWebResponse)webRequest.GetResponse();
+				webResponse.Close();
+			}
+		}
 
 		protected virtual HttpWebRequest CreateWebRequest(ILogglyAppenderConfig config, string tag)
 		{
 			var url = String.Concat(config.RootUrl, config.LogMode, config.InputKey);
-	        	//adding userAgent as tag in the log
-	        	url = String.Concat(url, "/tag/" + tag);
+				//adding userAgent as tag in the log
+				url = String.Concat(url, "/tag/" + tag);
 			var request = (HttpWebRequest)WebRequest.Create(url);
 			request.Method = "POST";
 			request.ReadWriteTimeout = request.Timeout = config.TimeoutInSeconds * 1000;
@@ -114,5 +114,5 @@ namespace log4net.loggly
 			request.ContentType = "application/json";
 			return request;
 		}
-    }  
+	}  
 }

--- a/source/log4net-loggly/LogglyFormatter.cs
+++ b/source/log4net-loggly/LogglyFormatter.cs
@@ -6,6 +6,7 @@ using log4net.Core;
 using Newtonsoft.Json;
 using System.Dynamic;
 using Newtonsoft.Json.Linq;
+using System.Text;
 
 namespace log4net.loggly
 {
@@ -13,6 +14,7 @@ namespace log4net.loggly
     {
         private Process _currentProcess;
         private ILogglyAppenderConfig _config;
+        public int EVENT_SIZE = 1000 * 1000;
 
         public LogglyFormatter()
         {
@@ -219,6 +221,7 @@ namespace log4net.loggly
         {
             string message = string.Empty;
             objInfo = null;
+            int bytesLengthAllowdToLoggly = EVENT_SIZE;
 
             if (loggingEvent.MessageObject != null)
             {
@@ -228,6 +231,11 @@ namespace log4net.loggly
                         || loggingEvent.MessageObject.GetType().FullName.Contains("StringFormatFormattedMessage"))
                 {
                     message = loggingEvent.MessageObject.ToString();
+                    int messageSizeInBytes = Encoding.Default.GetByteCount(message);
+                    if (messageSizeInBytes > bytesLengthAllowdToLoggly)
+                    {
+                        message = message.Substring(0, bytesLengthAllowdToLoggly);
+                    }
                 }
                 else
                 {

--- a/source/log4net-loggly/LogglyFormatter.cs
+++ b/source/log4net-loggly/LogglyFormatter.cs
@@ -10,303 +10,303 @@ using System.Text;
 
 namespace log4net.loggly
 {
-    public class LogglyFormatter : ILogglyFormatter
-    {
-        private Process _currentProcess;
-        private ILogglyAppenderConfig _config;
-        public int EVENT_SIZE = 1000 * 1000;
+	public class LogglyFormatter : ILogglyFormatter
+	{
+		private Process _currentProcess;
+		private ILogglyAppenderConfig _config;
+		public int EVENT_SIZE = 1000 * 1000;
 
-        public LogglyFormatter()
-        {
-            _currentProcess = Process.GetCurrentProcess();
-        }
+		public LogglyFormatter()
+		{
+			_currentProcess = Process.GetCurrentProcess();
+		}
 
-        public virtual void AppendAdditionalLoggingInformation(ILogglyAppenderConfig config, LoggingEvent loggingEvent)
-        {
-            this._config = config;
-        }
+		public virtual void AppendAdditionalLoggingInformation(ILogglyAppenderConfig config, LoggingEvent loggingEvent)
+		{
+			this._config = config;
+		}
 
-        public virtual string ToJson(LoggingEvent loggingEvent)
-        {
-            return PreParse(loggingEvent);
-        }
+		public virtual string ToJson(LoggingEvent loggingEvent)
+		{
+			return PreParse(loggingEvent);
+		}
 
-        public virtual string ToJson(IEnumerable<LoggingEvent> loggingEvents)
-        {
-            return JsonConvert.SerializeObject(loggingEvents.Select(PreParse),new JsonSerializerSettings(){
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-            });
-        }
+		public virtual string ToJson(IEnumerable<LoggingEvent> loggingEvents)
+		{
+			return JsonConvert.SerializeObject(loggingEvents.Select(PreParse),new JsonSerializerSettings(){
+				ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+			});
+		}
 
-        public virtual string ToJson(string renderedLog, DateTime timeStamp)
-        {
-            return ParseRenderedLog(renderedLog, timeStamp);
-        }
+		public virtual string ToJson(string renderedLog, DateTime timeStamp)
+		{
+			return ParseRenderedLog(renderedLog, timeStamp);
+		}
 
-        /// <summary>
-        /// Formats the log event to various JSON fields that are to be shown in Loggly.
-        /// </summary>
-        /// <param name="loggingEvent"></param>
-        /// <returns></returns>
-        private string PreParse(LoggingEvent loggingEvent)
-        {
-            //formating base logging info
-            dynamic _loggingInfo = new ExpandoObject();
-            _loggingInfo.timestamp = loggingEvent.TimeStamp.ToString(@"yyyy-MM-ddTHH\:mm\:ss.fffzzz");
-            _loggingInfo.level = loggingEvent.Level.DisplayName;
-            _loggingInfo.hostName = Environment.MachineName;
-            _loggingInfo.process = _currentProcess.ProcessName;
-            _loggingInfo.threadName = loggingEvent.ThreadName;
-            _loggingInfo.loggerName = loggingEvent.LoggerName;
+		/// <summary>
+		/// Formats the log event to various JSON fields that are to be shown in Loggly.
+		/// </summary>
+		/// <param name="loggingEvent"></param>
+		/// <returns></returns>
+		private string PreParse(LoggingEvent loggingEvent)
+		{
+			//formating base logging info
+			dynamic _loggingInfo = new ExpandoObject();
+			_loggingInfo.timestamp = loggingEvent.TimeStamp.ToString(@"yyyy-MM-ddTHH\:mm\:ss.fffzzz");
+			_loggingInfo.level = loggingEvent.Level.DisplayName;
+			_loggingInfo.hostName = Environment.MachineName;
+			_loggingInfo.process = _currentProcess.ProcessName;
+			_loggingInfo.threadName = loggingEvent.ThreadName;
+			_loggingInfo.loggerName = loggingEvent.LoggerName;
 
-            //handling messages
-            object _loggedObject = null;
-            string _message = GetMessageAndObjectInfo(loggingEvent, out _loggedObject);
+			//handling messages
+			object _loggedObject = null;
+			string _message = GetMessageAndObjectInfo(loggingEvent, out _loggedObject);
 
-            if (_message != string.Empty)
-            {
-                _loggingInfo.message = _message;
-            }
+			if (_message != string.Empty)
+			{
+				_loggingInfo.message = _message;
+			}
 
-            //handling exceptions
-            dynamic _exceptionInfo = GetExceptionInfo(loggingEvent);
-            if (_exceptionInfo != null)
-            {
-                _loggingInfo.exception = _exceptionInfo;
-            }
+			//handling exceptions
+			dynamic _exceptionInfo = GetExceptionInfo(loggingEvent);
+			if (_exceptionInfo != null)
+			{
+				_loggingInfo.exception = _exceptionInfo;
+			}
 
-            //handling threadcontext properties
-            string[] _threadContextProperties = ThreadContext.Properties.GetKeys();
-            if (_threadContextProperties != null && _threadContextProperties.Any())
-            {
-                var p = _loggingInfo as IDictionary<string, object>;
-                foreach (string key in _threadContextProperties)
-                {
-                    if ((ThreadContext.Properties[key] as IFixingRequired) != null
-                        && (ThreadContext.Properties[key] as IFixingRequired).GetFixedObject() != null)
-                    {
-                        p[key] = (ThreadContext.Properties[key] as IFixingRequired).GetFixedObject();
-                    }
-                    else
-                    {
-                        p[key] = ThreadContext.Properties[key].ToString();
-                    }
-                }
-            }
+			//handling threadcontext properties
+			string[] _threadContextProperties = ThreadContext.Properties.GetKeys();
+			if (_threadContextProperties != null && _threadContextProperties.Any())
+			{
+				var p = _loggingInfo as IDictionary<string, object>;
+				foreach (string key in _threadContextProperties)
+				{
+					if ((ThreadContext.Properties[key] as IFixingRequired) != null
+						&& (ThreadContext.Properties[key] as IFixingRequired).GetFixedObject() != null)
+					{
+						p[key] = (ThreadContext.Properties[key] as IFixingRequired).GetFixedObject();
+					}
+					else
+					{
+						p[key] = ThreadContext.Properties[key].ToString();
+					}
+				}
+			}
 
-            //handling logicalthreadcontext properties
-            if (this._config.LogicalThreadContextKeys != null)
-            {
-                var ltp = _loggingInfo as IDictionary<string, object>;
-                string[] _LogicalThreadContextProperties = this._config.LogicalThreadContextKeys.Split(',');
-                foreach (string key in _LogicalThreadContextProperties)
-                {
-                    if (LogicalThreadContext.Properties[key] != null)
-                    {
-                        if ((LogicalThreadContext.Properties[key] as IFixingRequired) != null
-                            && (LogicalThreadContext.Properties[key] as IFixingRequired).GetFixedObject() != null)
-                        {
-                            ltp[key] = (LogicalThreadContext.Properties[key] as IFixingRequired).GetFixedObject();
-                        }
-                        else
-                        {
-                            ltp[key] = LogicalThreadContext.Properties[key].ToString();
-                        }
-                    }
-                }
-            }
+			//handling logicalthreadcontext properties
+			if (this._config.LogicalThreadContextKeys != null)
+			{
+				var ltp = _loggingInfo as IDictionary<string, object>;
+				string[] _LogicalThreadContextProperties = this._config.LogicalThreadContextKeys.Split(',');
+				foreach (string key in _LogicalThreadContextProperties)
+				{
+					if (LogicalThreadContext.Properties[key] != null)
+					{
+						if ((LogicalThreadContext.Properties[key] as IFixingRequired) != null
+							&& (LogicalThreadContext.Properties[key] as IFixingRequired).GetFixedObject() != null)
+						{
+							ltp[key] = (LogicalThreadContext.Properties[key] as IFixingRequired).GetFixedObject();
+						}
+						else
+						{
+							ltp[key] = LogicalThreadContext.Properties[key].ToString();
+						}
+					}
+				}
+			}
 
-            //handling globalcontext properties
-            if (this._config.GlobalContextKeys != null)
-            {
-                var gcp = _loggingInfo as IDictionary<string, object>;
-                string[] _globalContextProperties = this._config.GlobalContextKeys.Split(',');
-                foreach (string key in _globalContextProperties)
-                {
-                    if (GlobalContext.Properties[key] != null)
-                    {
-                        if ((GlobalContext.Properties[key] as IFixingRequired) != null
-                            && (GlobalContext.Properties[key] as IFixingRequired).GetFixedObject() != null)
-                        {
-                            gcp[key] = (GlobalContext.Properties[key] as IFixingRequired).GetFixedObject();
-                        }
-                        else
-                        {
-                            gcp[key] = GlobalContext.Properties[key].ToString();
-                        }
-                    }
-                }
-            }
+			//handling globalcontext properties
+			if (this._config.GlobalContextKeys != null)
+			{
+				var gcp = _loggingInfo as IDictionary<string, object>;
+				string[] _globalContextProperties = this._config.GlobalContextKeys.Split(',');
+				foreach (string key in _globalContextProperties)
+				{
+					if (GlobalContext.Properties[key] != null)
+					{
+						if ((GlobalContext.Properties[key] as IFixingRequired) != null
+							&& (GlobalContext.Properties[key] as IFixingRequired).GetFixedObject() != null)
+						{
+							gcp[key] = (GlobalContext.Properties[key] as IFixingRequired).GetFixedObject();
+						}
+						else
+						{
+							gcp[key] = GlobalContext.Properties[key].ToString();
+						}
+					}
+				}
+			}
 
-            string jsonMessage = string.Empty;
-            if (TryGetParsedJsonFromLog(_loggingInfo, _loggedObject, out jsonMessage))
-            {
-                return jsonMessage;
-            }
-            else
-            {
-                //converting event info to Json string
-                return JsonConvert.SerializeObject(_loggingInfo,
-                new JsonSerializerSettings()
-                {
-                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                });
-            }
-        }
+			string jsonMessage = string.Empty;
+			if (TryGetParsedJsonFromLog(_loggingInfo, _loggedObject, out jsonMessage))
+			{
+				return jsonMessage;
+			}
+			else
+			{
+				//converting event info to Json string
+				return JsonConvert.SerializeObject(_loggingInfo,
+				new JsonSerializerSettings()
+				{
+					ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+				});
+			}
+		}
 
-        /// <summary>
-        /// Merged Rendered log and formatted timestamp in the single Json object
-        /// </summary>
-        /// <param name="log"></param>
-        /// <param name="timeStamp"></param>
-        /// <returns></returns>
-        private string ParseRenderedLog(string log, DateTime timeStamp)
-        {
-            dynamic _loggingInfo = new ExpandoObject();
-            _loggingInfo.timestamp = timeStamp.ToString(@"yyyy-MM-ddTHH\:mm\:ss.fffzzz");
+		/// <summary>
+		/// Merged Rendered log and formatted timestamp in the single Json object
+		/// </summary>
+		/// <param name="log"></param>
+		/// <param name="timeStamp"></param>
+		/// <returns></returns>
+		private string ParseRenderedLog(string log, DateTime timeStamp)
+		{
+			dynamic _loggingInfo = new ExpandoObject();
+			_loggingInfo.timestamp = timeStamp.ToString(@"yyyy-MM-ddTHH\:mm\:ss.fffzzz");
 
-            string jsonMessage = string.Empty;
-            if (TryGetParsedJsonFromLog(_loggingInfo, log, out jsonMessage))
-            {
-                return jsonMessage;
-            }
-            else
-            {
-                _loggingInfo.message = log;
-                return JsonConvert.SerializeObject(_loggingInfo,
-                    new JsonSerializerSettings()
-                    {
-                        PreserveReferencesHandling = PreserveReferencesHandling.Arrays,
-                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                    });
-            }
-        }
+			string jsonMessage = string.Empty;
+			if (TryGetParsedJsonFromLog(_loggingInfo, log, out jsonMessage))
+			{
+				return jsonMessage;
+			}
+			else
+			{
+				_loggingInfo.message = log;
+				return JsonConvert.SerializeObject(_loggingInfo,
+					new JsonSerializerSettings()
+					{
+						PreserveReferencesHandling = PreserveReferencesHandling.Arrays,
+						ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+					});
+			}
+		}
 
-        /// <summary>
-        /// Returns the exception information. Also takes care of the InnerException.  
-        /// </summary>
-        /// <param name="loggingEvent"></param>
-        /// <returns></returns>
-        private object GetExceptionInfo(LoggingEvent loggingEvent)
-        {
-            if (loggingEvent.ExceptionObject == null)
-            return null;
+		/// <summary>
+		/// Returns the exception information. Also takes care of the InnerException.  
+		/// </summary>
+		/// <param name="loggingEvent"></param>
+		/// <returns></returns>
+		private object GetExceptionInfo(LoggingEvent loggingEvent)
+		{
+			if (loggingEvent.ExceptionObject == null)
+			return null;
 
-            dynamic exceptionInfo = new ExpandoObject();
-            exceptionInfo.exceptionType = loggingEvent.ExceptionObject.GetType().FullName;
-            exceptionInfo.exceptionMessage = loggingEvent.ExceptionObject.Message;
-            exceptionInfo.stacktrace = loggingEvent.ExceptionObject.StackTrace;
+			dynamic exceptionInfo = new ExpandoObject();
+			exceptionInfo.exceptionType = loggingEvent.ExceptionObject.GetType().FullName;
+			exceptionInfo.exceptionMessage = loggingEvent.ExceptionObject.Message;
+			exceptionInfo.stacktrace = loggingEvent.ExceptionObject.StackTrace;
 
-            //most of the times dotnet exceptions contain important messages in the inner exceptions
-            if (loggingEvent.ExceptionObject.InnerException != null)
-            {
-                dynamic innerException = new
-                {
-                    innerExceptionType = loggingEvent.ExceptionObject.InnerException.GetType().FullName,
-                    innerExceptionMessage = loggingEvent.ExceptionObject.InnerException.Message,
-                    innerStacktrace = loggingEvent.ExceptionObject.InnerException.StackTrace
-                };
-                exceptionInfo.innerException = innerException;
-            }
-            return exceptionInfo;
-        }
+			//most of the times dotnet exceptions contain important messages in the inner exceptions
+			if (loggingEvent.ExceptionObject.InnerException != null)
+			{
+				dynamic innerException = new
+				{
+					innerExceptionType = loggingEvent.ExceptionObject.InnerException.GetType().FullName,
+					innerExceptionMessage = loggingEvent.ExceptionObject.InnerException.Message,
+					innerStacktrace = loggingEvent.ExceptionObject.InnerException.StackTrace
+				};
+				exceptionInfo.innerException = innerException;
+			}
+			return exceptionInfo;
+		}
 
-        /// <summary>
-        /// Returns a string type message if it is not a custom object,
-        /// otherwise returns custom object details
-        /// </summary>
-        /// <param name="loggingEvent"></param>
-        /// <returns></returns>
-        private string GetMessageAndObjectInfo(LoggingEvent loggingEvent, out object objInfo)
-        {
-            string message = string.Empty;
-            objInfo = null;
-            int bytesLengthAllowdToLoggly = EVENT_SIZE;
+		/// <summary>
+		/// Returns a string type message if it is not a custom object,
+		/// otherwise returns custom object details
+		/// </summary>
+		/// <param name="loggingEvent"></param>
+		/// <returns></returns>
+		private string GetMessageAndObjectInfo(LoggingEvent loggingEvent, out object objInfo)
+		{
+			string message = string.Empty;
+			objInfo = null;
+			int bytesLengthAllowdToLoggly = EVENT_SIZE;
 
-            if (loggingEvent.MessageObject != null)
-            {
-                if (loggingEvent.MessageObject.GetType() == typeof(string)
-                        //if it is sent by using InfoFormat method then treat it as a string message
-                        || loggingEvent.MessageObject.GetType().FullName == "log4net.Util.SystemStringFormat"
-                        || loggingEvent.MessageObject.GetType().FullName.Contains("StringFormatFormattedMessage"))
-                {
-                    message = loggingEvent.MessageObject.ToString();
-                    int messageSizeInBytes = Encoding.Default.GetByteCount(message);
-                    if (messageSizeInBytes > bytesLengthAllowdToLoggly)
-                    {
-                        message = message.Substring(0, bytesLengthAllowdToLoggly);
-                    }
-                }
-                else
-                {
-                    objInfo = loggingEvent.MessageObject;
-                }
-            }
-            else
-            {
-                //adding message as null so that the Loggly user
-                //can know that a null object is logged.
-                message = "null";
-            }
-            return message;
-        }
+			if (loggingEvent.MessageObject != null)
+			{
+				if (loggingEvent.MessageObject.GetType() == typeof(string)
+						//if it is sent by using InfoFormat method then treat it as a string message
+						|| loggingEvent.MessageObject.GetType().FullName == "log4net.Util.SystemStringFormat"
+						|| loggingEvent.MessageObject.GetType().FullName.Contains("StringFormatFormattedMessage"))
+				{
+					message = loggingEvent.MessageObject.ToString();
+					int messageSizeInBytes = Encoding.Default.GetByteCount(message);
+					if (messageSizeInBytes > bytesLengthAllowdToLoggly)
+					{
+						message = message.Substring(0, bytesLengthAllowdToLoggly);
+					}
+				}
+				else
+				{
+					objInfo = loggingEvent.MessageObject;
+				}
+			}
+			else
+			{
+				//adding message as null so that the Loggly user
+				//can know that a null object is logged.
+				message = "null";
+			}
+			return message;
+		}
 
-        /// <summary>
-        /// Tries to merge log with the logged object or rendered log
-        /// and converts to JSON
-        /// </summary>
-        /// <param name="loggingInfo"></param>
-        /// <param name="loggingObject"></param>
-        /// <param name="_loggingEventJSON"></param>
-        /// <returns></returns>
-        private bool TryGetParsedJsonFromLog(dynamic loggingInfo, object loggingObject, out string _loggingEventJSON)
-        {
-            //serialize the dynamic object to string
-            _loggingEventJSON = JsonConvert.SerializeObject(loggingInfo,
-            new JsonSerializerSettings()
-            {
-                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            }); 
-            
-            //if loggingObject is null then we need to go to further step
-            if (loggingObject == null)
-                return false;
-            
-            try
-            {
-                string _loggedObjectJSON = string.Empty;
-                if (loggingObject.GetType() == typeof(string))
-                {
-                    _loggedObjectJSON = loggingObject.ToString();
-                }
-                else
-                {
-                    _loggedObjectJSON = JsonConvert.SerializeObject(loggingObject,
-                        new JsonSerializerSettings()
-                        {
-                            PreserveReferencesHandling = PreserveReferencesHandling.Arrays,
-                            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-                        });
-                }
+		/// <summary>
+		/// Tries to merge log with the logged object or rendered log
+		/// and converts to JSON
+		/// </summary>
+		/// <param name="loggingInfo"></param>
+		/// <param name="loggingObject"></param>
+		/// <param name="_loggingEventJSON"></param>
+		/// <returns></returns>
+		private bool TryGetParsedJsonFromLog(dynamic loggingInfo, object loggingObject, out string _loggingEventJSON)
+		{
+			//serialize the dynamic object to string
+			_loggingEventJSON = JsonConvert.SerializeObject(loggingInfo,
+			new JsonSerializerSettings()
+			{
+				ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+			}); 
+			
+			//if loggingObject is null then we need to go to further step
+			if (loggingObject == null)
+				return false;
+			
+			try
+			{
+				string _loggedObjectJSON = string.Empty;
+				if (loggingObject.GetType() == typeof(string))
+				{
+					_loggedObjectJSON = loggingObject.ToString();
+				}
+				else
+				{
+					_loggedObjectJSON = JsonConvert.SerializeObject(loggingObject,
+						new JsonSerializerSettings()
+						{
+							PreserveReferencesHandling = PreserveReferencesHandling.Arrays,
+							ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+						});
+				}
 
-                //try to parse the logging object
-                JObject jObject = JObject.Parse(_loggedObjectJSON);
-                JObject jEvent = JObject.Parse(_loggingEventJSON);
+				//try to parse the logging object
+				JObject jObject = JObject.Parse(_loggedObjectJSON);
+				JObject jEvent = JObject.Parse(_loggingEventJSON);
 
-                //merge these two objects into one JSON string
-                jEvent.Merge(jObject, new JsonMergeSettings
-                {
-                    MergeArrayHandling = MergeArrayHandling.Union
-                });
+				//merge these two objects into one JSON string
+				jEvent.Merge(jObject, new JsonMergeSettings
+				{
+					MergeArrayHandling = MergeArrayHandling.Union
+				});
 
-                _loggingEventJSON = jEvent.ToString();
-                
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
-        }
-    }
+				_loggingEventJSON = jEvent.ToString();
+				
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+	}
 }

--- a/source/log4net-loggly/LogglySendBufferedLogs.cs
+++ b/source/log4net-loggly/LogglySendBufferedLogs.cs
@@ -40,7 +40,7 @@ namespace log4net.loggly
 						var response = (HttpWebResponse)e.Response;
 						if (response != null && response.StatusCode == HttpStatusCode.Forbidden)
 						{
-							LogglyClient.setValidInvalidFlag(false);
+							LogglyClient.setTokenValid(false);
 							Console.WriteLine("Loggly error: {0}", e.Message);
 							return;
 						}

--- a/source/log4net-loggly/LogglySendBufferedLogs.cs
+++ b/source/log4net-loggly/LogglySendBufferedLogs.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace log4net.loggly
+{
+    public class LogglySendBufferedLogs
+    {
+            public static string message;
+            public static List<string> arrayMessage = new List<string>();
+            public static ILogglyClient Client = new LogglyClient();
+          
+       public static void sendBufferedLogsToLoggly(ILogglyAppenderConfig config, bool isBulk)
+        {
+            if (LogglyStoreLogsInBuffer.arrBufferedMessage.Count > 0)
+            {
+                
+                int bulkModeBunch = 100;
+                int inputModeBunch = 1;
+                int logInBunch = isBulk ? bulkModeBunch : inputModeBunch;
+                arrayMessage = LogglyStoreLogsInBuffer.arrBufferedMessage.Take(logInBunch).ToList();
+                message = isBulk ? String.Join(System.Environment.NewLine, arrayMessage) : arrayMessage[0];
+                    try
+                    {
+                        Client.Send(config, message, isBulk);
+                        var tempList = LogglyStoreLogsInBuffer.arrBufferedMessage;
+                        if (LogglyStoreLogsInBuffer.arrBufferedMessage.Count < arrayMessage.Count)
+                        {
+                            LogglyStoreLogsInBuffer.arrBufferedMessage.Clear();
+                        }
+                        else
+                        {
+                            tempList.RemoveRange(0, arrayMessage.Count);
+                        }
+                        LogglyStoreLogsInBuffer.arrBufferedMessage = tempList;
+                    }
+                    catch (WebException e)
+                    {
+                        var response = (HttpWebResponse)e.Response;
+                        if (response != null && response.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            LogglyClient.setValidInvalidFlag(false);
+                            Console.WriteLine("Loggly error: {0}", e.Message);
+                            return;
+                        }
+                    }
+            } 
+        }
+
+    }
+}
+

--- a/source/log4net-loggly/LogglySendBufferedLogs.cs
+++ b/source/log4net-loggly/LogglySendBufferedLogs.cs
@@ -5,49 +5,49 @@ using System.Net;
 
 namespace log4net.loggly
 {
-    public class LogglySendBufferedLogs
-    {
-            public static string message;
-            public static List<string> arrayMessage = new List<string>();
-            public static ILogglyClient Client = new LogglyClient();
-          
-       public static void sendBufferedLogsToLoggly(ILogglyAppenderConfig config, bool isBulk)
-        {
-            if (LogglyStoreLogsInBuffer.arrBufferedMessage.Count > 0)
-            {
-                
-                int bulkModeBunch = 100;
-                int inputModeBunch = 1;
-                int logInBunch = isBulk ? bulkModeBunch : inputModeBunch;
-                arrayMessage = LogglyStoreLogsInBuffer.arrBufferedMessage.Take(logInBunch).ToList();
-                message = isBulk ? String.Join(System.Environment.NewLine, arrayMessage) : arrayMessage[0];
-                    try
-                    {
-                        Client.Send(config, message, isBulk);
-                        var tempList = LogglyStoreLogsInBuffer.arrBufferedMessage;
-                        if (LogglyStoreLogsInBuffer.arrBufferedMessage.Count < arrayMessage.Count)
-                        {
-                            LogglyStoreLogsInBuffer.arrBufferedMessage.Clear();
-                        }
-                        else
-                        {
-                            tempList.RemoveRange(0, arrayMessage.Count);
-                        }
-                        LogglyStoreLogsInBuffer.arrBufferedMessage = tempList;
-                    }
-                    catch (WebException e)
-                    {
-                        var response = (HttpWebResponse)e.Response;
-                        if (response != null && response.StatusCode == HttpStatusCode.Forbidden)
-                        {
-                            LogglyClient.setValidInvalidFlag(false);
-                            Console.WriteLine("Loggly error: {0}", e.Message);
-                            return;
-                        }
-                    }
-            } 
-        }
+	public class LogglySendBufferedLogs
+	{
+			public static string message;
+			public static List<string> arrayMessage = new List<string>();
+			public static ILogglyClient Client = new LogglyClient();
+		  
+	   public static void sendBufferedLogsToLoggly(ILogglyAppenderConfig config, bool isBulk)
+		{
+			if (LogglyStoreLogsInBuffer.arrBufferedMessage.Count > 0)
+			{
+				
+				int bulkModeBunch = 100;
+				int inputModeBunch = 1;
+				int logInBunch = isBulk ? bulkModeBunch : inputModeBunch;
+				arrayMessage = LogglyStoreLogsInBuffer.arrBufferedMessage.Take(logInBunch).ToList();
+				message = isBulk ? String.Join(System.Environment.NewLine, arrayMessage) : arrayMessage[0];
+					try
+					{
+						Client.Send(config, message, isBulk);
+						var tempList = LogglyStoreLogsInBuffer.arrBufferedMessage;
+						if (LogglyStoreLogsInBuffer.arrBufferedMessage.Count < arrayMessage.Count)
+						{
+							LogglyStoreLogsInBuffer.arrBufferedMessage.Clear();
+						}
+						else
+						{
+							tempList.RemoveRange(0, arrayMessage.Count);
+						}
+						LogglyStoreLogsInBuffer.arrBufferedMessage = tempList;
+					}
+					catch (WebException e)
+					{
+						var response = (HttpWebResponse)e.Response;
+						if (response != null && response.StatusCode == HttpStatusCode.Forbidden)
+						{
+							LogglyClient.setValidInvalidFlag(false);
+							Console.WriteLine("Loggly error: {0}", e.Message);
+							return;
+						}
+					}
+			} 
+		}
 
-    }
+	}
 }
 

--- a/source/log4net-loggly/LogglyStoreLogsInBuffer.cs
+++ b/source/log4net-loggly/LogglyStoreLogsInBuffer.cs
@@ -6,14 +6,13 @@ namespace log4net.loggly
 {
     class LogglyStoreLogsInBuffer
     {
-        public static int bufferSize = 500;
         public static List<string> arrBufferedMessage = new List<string>();
         public static List<string> tempList = new List<string>();
-
+        
         public static void storeBulkLogs(ILogglyAppenderConfig config, List<string> logs, bool isBulk)
         {
             if (logs.Count == 0) return;
-            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + logs.Count) - bufferSize;
+            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + logs.Count) - config.BufferSize;
             if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);   
        
             arrBufferedMessage = logs.Concat(arrBufferedMessage).ToList();
@@ -22,7 +21,7 @@ namespace log4net.loggly
         public static void storeInputLogs(ILogglyAppenderConfig config, string message, bool isBulk)
         {
             if (message == String.Empty) return;
-            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + 1) - bufferSize;
+            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + 1) - config.BufferSize;
             if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);
             arrBufferedMessage.Add(message);
         }

--- a/source/log4net-loggly/LogglyStoreLogsInBuffer.cs
+++ b/source/log4net-loggly/LogglyStoreLogsInBuffer.cs
@@ -4,26 +4,26 @@ using System.Linq;
 
 namespace log4net.loggly
 {
-    class LogglyStoreLogsInBuffer
-    {
-        public static List<string> arrBufferedMessage = new List<string>();
-        public static List<string> tempList = new List<string>();
-        
-        public static void storeBulkLogs(ILogglyAppenderConfig config, List<string> logs, bool isBulk)
-        {
-            if (logs.Count == 0) return;
-            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + logs.Count) - config.BufferSize;
-            if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);   
-       
-            arrBufferedMessage = logs.Concat(arrBufferedMessage).ToList();
-        }
+	class LogglyStoreLogsInBuffer
+	{
+		public static List<string> arrBufferedMessage = new List<string>();
+		public static List<string> tempList = new List<string>();
+		
+		public static void storeBulkLogs(ILogglyAppenderConfig config, List<string> logs, bool isBulk)
+		{
+			if (logs.Count == 0) return;
+			int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + logs.Count) - config.BufferSize;
+			if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);   
+	   
+			arrBufferedMessage = logs.Concat(arrBufferedMessage).ToList();
+		}
 
-        public static void storeInputLogs(ILogglyAppenderConfig config, string message, bool isBulk)
-        {
-            if (message == String.Empty) return;
-            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + 1) - config.BufferSize;
-            if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);
-            arrBufferedMessage.Add(message);
-        }
-    }
+		public static void storeInputLogs(ILogglyAppenderConfig config, string message, bool isBulk)
+		{
+			if (message == String.Empty) return;
+			int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + 1) - config.BufferSize;
+			if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);
+			arrBufferedMessage.Add(message);
+		}
+	}
 }

--- a/source/log4net-loggly/LogglyStoreLogsInBuffer.cs
+++ b/source/log4net-loggly/LogglyStoreLogsInBuffer.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace log4net.loggly
+{
+    class LogglyStoreLogsInBuffer
+    {
+        public static int bufferSize = 500;
+        public static List<string> arrBufferedMessage = new List<string>();
+        public static List<string> tempList = new List<string>();
+
+        public static void storeBulkLogs(ILogglyAppenderConfig config, List<string> logs, bool isBulk)
+        {
+            if (logs.Count == 0) return;
+            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + logs.Count) - bufferSize;
+            if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);   
+       
+            arrBufferedMessage = logs.Concat(arrBufferedMessage).ToList();
+        }
+
+        public static void storeInputLogs(ILogglyAppenderConfig config, string message, bool isBulk)
+        {
+            if (message == String.Empty) return;
+            int numberOfLogsToBeRemoved = (arrBufferedMessage.Count + 1) - bufferSize;
+            if (numberOfLogsToBeRemoved > 0) arrBufferedMessage.RemoveRange(0, numberOfLogsToBeRemoved);
+            arrBufferedMessage.Add(message);
+        }
+    }
+}

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -50,7 +50,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ILogglyAppenderConfig.cs" />
-    <Compile Include="ILogglyBufferedLogs.cs" />
     <Compile Include="ILogglyClient.cs" />
     <Compile Include="LogglyAppenderConfig.cs" />
     <Compile Include="LogglyAsyncHandler.cs" />

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ILogglyAppenderConfig.cs" />
+    <Compile Include="ILogglyBufferedLogs.cs" />
     <Compile Include="ILogglyClient.cs" />
     <Compile Include="LogglyAppenderConfig.cs" />
     <Compile Include="LogglyAsyncHandler.cs" />
@@ -58,7 +59,9 @@
     <Compile Include="LogglyFormatter.cs" />
     <Compile Include="ILogglyFormatter.cs" />
     <Compile Include="LogglyAppender.cs" />
+    <Compile Include="LogglyStoreLogsInBuffer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="LogglySendBufferedLogs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -1,76 +1,76 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{ABE2B1B6-A83C-4604-AF87-FAAC3976530D}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>log4net.loggly</RootNamespace>
-    <AssemblyName>log4net-loggly</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ILogglyAppenderConfig.cs" />
-    <Compile Include="ILogglyClient.cs" />
-    <Compile Include="LogglyAppenderConfig.cs" />
-    <Compile Include="LogglyAsyncHandler.cs" />
-    <Compile Include="LogglyBufferringAppender.cs" />
-    <Compile Include="LogglyClient.cs" />
-    <Compile Include="LogglyFormatter.cs" />
-    <Compile Include="ILogglyFormatter.cs" />
-    <Compile Include="LogglyAppender.cs" />
-    <Compile Include="LogglyStoreLogsInBuffer.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="LogglySendBufferedLogs.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProductVersion>8.0.30703</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectGuid>{ABE2B1B6-A83C-4604-AF87-FAAC3976530D}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>log4net.loggly</RootNamespace>
+		<AssemblyName>log4net-loggly</AssemblyName>
+		<TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>full</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+			<SpecificVersion>False</SpecificVersion>
+			<HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+		</Reference>
+		<Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+			<HintPath>..\packages\Newtonsoft.Json.8.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+			<Private>True</Private>
+		</Reference>
+		<Reference Include="System" />
+		<Reference Include="System.Configuration" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Xml.Linq" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System.Data" />
+		<Reference Include="System.Xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="ILogglyAppenderConfig.cs" />
+		<Compile Include="ILogglyClient.cs" />
+		<Compile Include="LogglyAppenderConfig.cs" />
+		<Compile Include="LogglyAsyncHandler.cs" />
+		<Compile Include="LogglyBufferringAppender.cs" />
+		<Compile Include="LogglyClient.cs" />
+		<Compile Include="LogglyFormatter.cs" />
+		<Compile Include="ILogglyFormatter.cs" />
+		<Compile Include="LogglyAppender.cs" />
+		<Compile Include="LogglyStoreLogsInBuffer.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="LogglySendBufferedLogs.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="packages.config" />
+	</ItemGroup>
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+	<!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+			 Other similar extension points exist, see Microsoft.Common.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
 </Project>

--- a/source/log4net-loggly/log4net-loggly.nuspec
+++ b/source/log4net-loggly/log4net-loggly.nuspec
@@ -1,20 +1,20 @@
 <?xml version="1.0"?>
 <package >
-  <metadata>
-    <id>log4net-loggly</id>
-    <version>7.2.3</version>
-    <authors>Loggly</authors>
-    <owners>Loggly</owners>
-    <licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
-    <projectUrl>http://github.com/loggly/log4net-loggly</projectUrl>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Custom log4Net Appender to send logs to Loggly</description>
-    <releaseNotes>Decrease wait time interval for bulk mode.</releaseNotes>
-    <copyright>Copyright 2016</copyright>
-    <tags>Loggly-log4net log4net appender logs</tags>
-    <dependencies>
-      <dependency id="log4net" version="2.0.3" />
-      <dependency id="Newtonsoft.Json" version="8.0.1" />
-    </dependencies>
-  </metadata>
+	<metadata>
+		<id>log4net-loggly</id>
+		<version>7.2.3</version>
+		<authors>Loggly</authors>
+		<owners>Loggly</owners>
+		<licenseUrl>http://opensource.org/licenses/MIT</licenseUrl>
+		<projectUrl>http://github.com/loggly/log4net-loggly</projectUrl>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<description>Custom log4Net Appender to send logs to Loggly</description>
+		<releaseNotes>Decrease wait time interval for bulk mode.</releaseNotes>
+		<copyright>Copyright 2016</copyright>
+		<tags>Loggly-log4net log4net appender logs</tags>
+		<dependencies>
+			<dependency id="log4net" version="2.0.3" />
+			<dependency id="Newtonsoft.Json" version="8.0.1" />
+		</dependencies>
+	</metadata>
 </package>

--- a/source/log4net-loggly/packages.config
+++ b/source/log4net-loggly/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net4" />
-  <package id="Newtonsoft.Json" version="8.0.1" targetFramework="net4" />
+	<package id="log4net" version="2.0.3" targetFramework="net4" />
+	<package id="Newtonsoft.Json" version="8.0.1" targetFramework="net4" />
 </packages>


### PR DESCRIPTION
- [x] Store logs during network outage.
- [x] Rotate stored logs while running out of memory.
- [x] Send buffered logs after re-connection.
- [x] Handle bad token error. 
- [x] Truncate event over 1 MB size.
- [x] Make buffer option configurable.
- [x] Refactor: Fix linting issue(Library follow mixed spacing tab and 4 spaces)
- [x] Testing