### PR TITLE
Target netstandards2.0 in ClassLib instead of netcoreapp2.0

### DIFF
--- a/source/log4net-loggly.UnitTests/LogglyFormatterTest.cs
+++ b/source/log4net-loggly.UnitTests/LogglyFormatterTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace log4net_loggly.UnitTests
 {
     using System;
+    using AutoFixture;
     using FluentAssertions;
     using JetBrains.Annotations;
     using log4net;
@@ -11,7 +12,6 @@
     using Moq;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using Ploeh.AutoFixture;
     using Xunit;
 
     [UsedImplicitly]

--- a/source/log4net-loggly.UnitTests/log4net-loggly.UnitTests.csproj
+++ b/source/log4net-loggly.UnitTests/log4net-loggly.UnitTests.csproj
@@ -7,7 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="3.50.6" />
+    <PackageReference Include="AutoFixture" Version="4.4.0" />
+    <PackageReference Include="AutoFixture.SeedExtensions" Version="4.4.0" />
     <PackageReference Include="Castle.Core" Version="4.1.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="JetBrains.Annotations" Version="11.0.0" />
@@ -20,6 +21,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\log4net-loggly\log4net-loggly.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -11,7 +11,7 @@
     <Product>Loggly</Product>
     <PackageProjectUrl>http://github.com/loggly/log4net-loggly</PackageProjectUrl>
     <Description>Custom log4Net Appender to send logs to Loggly</Description>
-    <PackageReleaseNotes>.NET Core 2.0 support with old .NET frameworks compatibility</PackageReleaseNotes>
+    <PackageReleaseNotes>.NET Standard 2.0 support with old .NET frameworks compatibility</PackageReleaseNotes>
     <Copyright>Copyright 2017</Copyright>
     <PackageTags>Loggly-log4net log4net appender logs</PackageTags>
   </PropertyGroup>

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <DebugType>full</DebugType>
-    <TargetFrameworks>netcoreapp2.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>8.0.0</Version>
     <Authors>Loggly</Authors>

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -4,7 +4,7 @@
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>8.0.0</Version>
+    <Version>8.0.1</Version>
     <Authors>Loggly</Authors>
     <Company>Loggly</Company>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>


### PR DESCRIPTION
Target netstandards2.0 in ClassLib instead of netcoreapp2.0
Also updates AutoFixure to 4.4.0 due to the netstandards support.

