### PR TITLE
Execute retry logic in Send() method even if exception is not of type WebException

### DIFF
--- a/source/log4net-loggly.UnitTests/LogglyClientTest.cs
+++ b/source/log4net-loggly.UnitTests/LogglyClientTest.cs
@@ -93,6 +93,24 @@ namespace log4net_loggly.UnitTests
         }
 
         [Fact]
+        public void RetriesSendWhenSystemErrorOccurs()
+        {
+            _webRequestMock.Setup(x => x.GetResponse())
+                .Throws(new OperationCanceledException("The operation was canceled."));
+
+            var config = new Config
+            {
+                MaxSendRetries = 3
+            };
+            var client = new LogglyClient(config);
+
+            client.Send(new[] { "test message" }, 1);
+
+            _webRequestMock.Verify(x => x.GetResponse(), Times.Exactly(config.MaxSendRetries + 1),
+                "Generic system error should be retried");
+        }
+
+        [Fact]
         public void SendsCorrectData()
         {
             var client = new LogglyClient(new Config());

--- a/source/log4net-loggly/LogglyClient.cs
+++ b/source/log4net-loggly/LogglyClient.cs
@@ -32,17 +32,20 @@ namespace log4net.loggly
                     SendToLoggly(message);
                     break;
                 }
-                catch (WebException e)
+                catch (Exception e)
                 {
-                    var response = (HttpWebResponse)e.Response;
-                    if (response != null && response.StatusCode == HttpStatusCode.Forbidden)
+                    if (e is WebException)
                     {
-                        _isTokenValid = false;
-                        ErrorReporter.ReportError($"LogglyClient: Provided Loggly customer token '{_config.CustomerToken}' is invalid. No logs will be sent to Loggly.");
-                    }
-                    else
-                    {
-                        ErrorReporter.ReportError($"LogglyClient: Error sending logs to Loggly: {e.Message}");
+                        var response = ((WebException)e).Response as HttpWebResponse;
+                        if (response != null && response.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            _isTokenValid = false;
+                            ErrorReporter.ReportError($"LogglyClient: Provided Loggly customer token '{_config.CustomerToken}' is invalid. No logs will be sent to Loggly.");
+                        }
+                        else
+                        {
+                            ErrorReporter.ReportError($"LogglyClient: Error sending logs to Loggly: {e.Message}");
+                        }
                     }
 
                     currentRetry++;

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -4,7 +4,7 @@
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>9.0.1</Version>
+    <Version>9.0.2</Version>
     <Authors>Loggly</Authors>
     <Company>Loggly</Company>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
@@ -23,8 +23,8 @@
     <Copyright>Copyright 2019</Copyright>
     <PackageTags>Loggly-log4net log4net appender logs</PackageTags>
     <RootNamespace>log4net.loggly</RootNamespace>
-    <AssemblyVersion>9.0.0.1</AssemblyVersion>
-    <FileVersion>9.0.0.1</FileVersion>
+    <AssemblyVersion>9.0.0.2</AssemblyVersion>
+    <FileVersion>9.0.0.2</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -4,7 +4,7 @@
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
     <Authors>Loggly</Authors>
     <Company>Loggly</Company>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
@@ -14,7 +14,7 @@
     <PackageReleaseNotes>
       - Fixed serialization of logged objects. They are now again serialized as full JSON instead of their .NET type name.
       - Fixed issue when logicalThreadContextKeys and globalContextKeys were ignored if &lt;layout&gt; definition was used.
-      - Fixed priority of GlobalContext, ThreadContext, LogicalThreadContext and EventContext properties. It was in reverse order than it should be. Correct priority from highest to lowest is EventContext -> LogicalThreadContext -> ThreadContext -> GlobalContext
+      - Fixed priority of GlobalContext, ThreadContext, LogicalThreadContext and EventContext properties. It was in reverse order than it should be. Correct priority from highest to lowest is EventContext -&gt; LogicalThreadContext -&gt; ThreadContext -&gt; GlobalContext
       - Removed option to use Loggly /inputs HTTP endpoint. All logs are sent via /bulk endpoint.
       - Changed inner exception property names. Previously the exception properties were named "exceptionType, exceptionMessage" etc. but inner exception properties were "innerExceptionType, innerExceptionMessage" etc. This was unified and inner exception properties are now also named "exceptionType, exceptionMessage" etc.
       - Changed default number of inner exceptions that are sent in log from 1 to 4.
@@ -23,6 +23,8 @@
     <Copyright>Copyright 2019</Copyright>
     <PackageTags>Loggly-log4net log4net appender logs</PackageTags>
     <RootNamespace>log4net.loggly</RootNamespace>
+    <AssemblyVersion>9.0.0.1</AssemblyVersion>
+    <FileVersion>9.0.0.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/log4net-loggly/log4net-loggly.csproj
+++ b/source/log4net-loggly/log4net-loggly.csproj
@@ -4,7 +4,7 @@
     <DebugType>full</DebugType>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>9.0.2</Version>
+    <Version>9.0.3</Version>
     <Authors>Loggly</Authors>
     <Company>Loggly</Company>
     <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
@@ -23,8 +23,8 @@
     <Copyright>Copyright 2019</Copyright>
     <PackageTags>Loggly-log4net log4net appender logs</PackageTags>
     <RootNamespace>log4net.loggly</RootNamespace>
-    <AssemblyVersion>9.0.0.2</AssemblyVersion>
-    <FileVersion>9.0.0.2</FileVersion>
+    <AssemblyVersion>9.0.0.3</AssemblyVersion>
+    <FileVersion>9.0.0.3</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hello,

We had an issue in production yesterday that caused our application to go offline on a couple of web servers for about a 1.5 minutes. During our investigation we found the following call stack:

Apr 24 14:59:12: Unhandled Exception: System.OperationCanceledException: The operation was canceled.
Apr 24 14:59:12:    at System.Net.HttpWebRequest.GetResponse()
Apr 24 14:59:12:    at log4net.loggly.LogglyClient.Send(ILogglyAppenderConfig config, String message)
Apr 24 14:59:12:    at log4net.loggly.LogglyAsyncHandler.SendLogs()
Apr 24 14:59:12:    at System.Threading.Thread.ThreadMain_ThreadStart()
Apr 24 14:59:12:    at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)

It looks like the LogglyClient received an exception of type System.OperationCanceledException which is not handled in the Send() method so it crashed our process. This PR accounts for generic exceptions and executes the same retry logic. Applicable unit test has also been added.