### PR TITLE
fix: use no indentation for json logging

### DIFF
--- a/source/log4net-loggly/LogglyFormatter.cs
+++ b/source/log4net-loggly/LogglyFormatter.cs
@@ -83,6 +83,7 @@ namespace log4net.loggly
                 loggingInfo,
                 new JsonSerializerSettings
                 {
+                    Formatting = Formatting.None,
                     ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
                 });
         }


### PR DESCRIPTION
Enabling indentation for json in logs by setting default json serializer settings causes those logs to be split over multiple entries due to the new line characters. To avoid this the serializer formatting should always be set to override as "None".